### PR TITLE
Fix column name consistency with input data file

### DIFF
--- a/budget_forecast_app/forecast/ml/prophet_model.py
+++ b/budget_forecast_app/forecast/ml/prophet_model.py
@@ -8,6 +8,7 @@ Loads CSV, trains Prophet model, and returns forecast + Plotly figure.
 from .legacy_prophet_model import *
 from .enums import ForecastType
 from .utils.setup_logging import setup_logging
+from typing import List, Dict
 
 def run_prophet_forecast(
         csv_path: str,
@@ -34,6 +35,22 @@ def run_prophet_forecast(
     try:
         data = pd.read_csv(csv_path)
         logger.info(f"Dataset loaded successfully. Shape: {data.shape}")
+        COLUMN_MAPPINGS = {
+            "accountName": ["accountName", "vendor_name", "vendor_account_name"],
+            "spend": ["spend", "cost", "public_on_demand", "public_on_demand_cost", "total_amortized_cost"],
+            "serviceName": ["serviceName", "enhanced_service_name"],
+            "month": ["month", "date", "year_month"]
+        }
+
+        mapped_columns = get_mapped_columns(data.columns.tolist(), COLUMN_MAPPINGS)
+        logger.info(f"DEBUG mapped columns after get_mapped_columns method in prophet_model.py - {mapped_columns}")
+        rename_dict = {actual_col: canonical_col for canonical_col, actual_col in mapped_columns.items()}
+        logger.info(f"DEBUG Renamed Dict Column Names: {rename_dict}")
+        # Apply the mapping to the DataFrame
+        data = data.rename(columns=rename_dict)
+        logger.info(f"DEBUG Data Column Names after renaming post remap: {data.columns}")
+
+
     except FileNotFoundError:
         logger.error("Dataset file not found.")
         raise
@@ -65,3 +82,21 @@ def run_prophet_forecast(
 
 
     return forecast_df, historical_df
+
+
+def get_mapped_columns(available_columns, COLUMN_MAPPINGS: Dict[str, str]) -> Dict[str, str]:
+    """
+    Maps available column names to standardized canonical names based on COLUMN_MAPPINGS.
+    """
+    columns_dict = {}
+
+    # 2. Iterate dynamically through the mappings
+    for canonical_name, possible_names in COLUMN_MAPPINGS.items():
+        # 3. Find the first matching column name
+        match = next((name for name in possible_names if name in available_columns), None)
+
+        if match:
+            columns_dict[canonical_name] = match
+
+    return columns_dict
+

--- a/budget_forecast_app/forecast/views.py
+++ b/budget_forecast_app/forecast/views.py
@@ -8,6 +8,7 @@ from django.views.decorators.csrf import csrf_exempt
 from .ml.main import run_forecast
 from .ml.utils.setup_logging import setup_logging
 from .ml.enums import ForecastType
+from .ml.prophet_model import get_mapped_columns
 
 import plotly.io as pio
 import json
@@ -187,8 +188,11 @@ def upload_file(request):
 
 
 def get_suggestions(request):
+    logger.info(f"DEBUG in get_suggestions views")
+    logger.info(f"DEBUG request in get_suggestions views- {request}")
+    logger.info(f"DEBUG REQUEST SESSION in get_suggestions views- {request.session}")
     query = request.GET.get("q", "").strip().lower()
-    field = request.GET.get("field")  # 'account', 'service', 'bucode', 'segment'
+    field = request.GET.get("field")  # 'account', 'service', 'bucode'or 'segment'
 
     filename = request.session.get("csv_base_filename")
     if not filename:
@@ -214,6 +218,21 @@ def get_suggestions(request):
     try:
         df = pd.read_csv(file_path)
         print(f"✅ Loaded file with columns: {list(df.columns)}")
+        logger.info(f"Dataset loaded successfully for get_suggestions. Shape: {df.shape}")
+        COLUMN_MAPPINGS = {
+            "accountName": ["accountName", "vendor_name", "vendor_account_name"],
+            "spend": ["spend", "cost", "public_on_demand", "public_on_demand_cost", "total_amortized_cost"],
+            "serviceName": ["serviceName", "enhanced_service_name"],
+            "month": ["month", "date", "year_month"]
+        }
+
+        mapped_columns = get_mapped_columns(df.columns.tolist(), COLUMN_MAPPINGS)
+        logger.info(f"DEBUG for get_suggestions mapped columns after get_mapped_columns method in prophet_model.py - {mapped_columns}")
+        rename_dict = {actual_col: canonical_col for canonical_col, actual_col in mapped_columns.items()}
+        logger.info(f"DEBUG for get_suggestions Renamed Dict Column Names: {rename_dict}")
+        # Apply the mapping to the DataFrame
+        df = df.rename(columns=rename_dict)
+        logger.info(f"DEBUG for get_suggestions DF Column Names after renaming post remap: {df.columns}")
 
         if field == "account":
             col_name = "accountName"

--- a/budget_forecast_app/requirements.txt
+++ b/budget_forecast_app/requirements.txt
@@ -5,7 +5,7 @@ Django==4.2.25
 django-vite==3.0.1
 
 # Core data science libraries
-pandas>=1.5.0
+pandas>=2.0.1
 numpy>=1.21.0
 
 # Machine learning libraries


### PR DESCRIPTION
- Fix consistent column names issue.
- When user uploads csv file with different column names than expected, the columns are remapped into:
```
COLUMN_MAPPINGS = {
            "accountName": ["accountName", "vendor_name", "vendor_account_name"],
            "spend": ["spend", "cost", "public_on_demand", "public_on_demand_cost", "total_amortized_cost"],
            "serviceName": ["serviceName", "enhanced_service_name"],
            "month": ["month", "date", "year_month"]
        }
```
- Also fixing the get_suggestions issue when reading columns while generating suggestions based on parsed csv file with similar fix.
- Updating pandas version to fix prophet model dependency issue : freq "M" to "ME"