### PR TITLE
Add interactive Brush component for panning daily forecasts

### DIFF
--- a/budget_forecast_app/forecast/ml/base_model.py
+++ b/budget_forecast_app/forecast/ml/base_model.py
@@ -10,8 +10,8 @@ class BaseForecaster(ABC):
         self.hyperparameters = hyperparameters or {}
         self.kwargs = kwargs
 
-        gran_str = granularity.value if hasattr(granularity, 'value') else str(granularity).lower()
-        self.is_daily = gran_str == 'daily'
+        gran_str = granularity.value if hasattr(granularity, 'value') else str(granularity)
+        self.is_daily = gran_str.lower() == 'daily'
         self.freq = 'D' if self.is_daily else 'MS'
         self.periods = kwargs.get('periods', 90 if self.is_daily else 24)
 
@@ -23,10 +23,11 @@ class BaseForecaster(ABC):
         if df.index.name in ['date', 'month', 'Month']:
             df = df.reset_index()
 
-        # Rename columns to standard 'date'
-        rename_map = {col: 'date' for col in ['month', 'Month', date_col] if col in df.columns}
-        if rename_map:
-            df = df.rename(columns=rename_map)
+        # Safely normalize the time column to 'date' without creating duplicates
+        for col in ['date', 'month', 'Month', 'ds']:
+            if col in df.columns and col != 'date':
+                df = df.rename(columns={col: 'date'})
+                break  # Only rename the first valid time column we find
 
         if 'date' not in df.columns:
             raise KeyError(f"Expected a date column, but found: {df.columns.tolist()}")
@@ -46,10 +47,10 @@ class BaseForecaster(ABC):
             raise ValueError("The provided dataset is empty and contains no historical spend data.")
 
         # 1. Dynamic Column Validation
-        if self.granularity == Granularity.MONTHLY and ('month' not in df.columns or 'spend' not in df.columns):
-            raise ValueError("DataFrame for monthly granularity must contain 'month' and 'spend' columns.")
-        elif self.granularity == Granularity.DAILY and ('date' not in df.columns or 'spend' not in df.columns):
-            raise ValueError("DataFrame for daily granularity must contain 'date' and 'spend' columns.")
+        has_time_col = any(col in df.columns for col in ['date', 'month', 'Month'])
+        if not has_time_col or 'spend' not in df.columns:
+            raise ValueError(
+                "DataFrame must contain a time column ('date', 'month', or 'Month') and a 'spend' column.")
 
         # 2. Dynamic Filtering using kwargs passed to the BaseForecaster
         data = df.copy()

--- a/budget_forecast_app/forecast/services/services.py
+++ b/budget_forecast_app/forecast/services/services.py
@@ -127,15 +127,18 @@ class ForecastOrchestrationService:
 
         # 2. Map strings to Enums
         try:
-            forecast_type = ForecastType(forecast_type_str)
-            granularity = Granularity(granularity_str)
-        except ValueError:
-            logger.warning("Invalid enums passed, falling back to defaults.")
+            forecast_type = next(
+                (e for e in ForecastType if str(e.value).lower() == str(forecast_type_str).lower()),
+                ForecastType.OVERALL_AGGREGATE
+            )
+            granularity = next(
+                (e for e in Granularity if str(e.value).lower() == str(granularity_str).lower()),
+                Granularity.MONTHLY
+            )
+        except Exception as e:
+            logger.warning(f"Invalid enums passed, falling back to defaults. Error: {e}")
             forecast_type = ForecastType.OVERALL_AGGREGATE
             granularity = Granularity.MONTHLY
-
-        if granularity == Granularity.MONTHLY:
-            df.rename(columns={'date': 'month'}, inplace=True)
 
         # 3. Execute Strategy Pattern Engine
         result = run_forecast(df, forecast_type, granularity=granularity, model_name = model_name,

--- a/budget_forecast_app/frontend/src/pages/KharchuDashboard/KharchuDashboard.tsx
+++ b/budget_forecast_app/frontend/src/pages/KharchuDashboard/KharchuDashboard.tsx
@@ -507,37 +507,6 @@ export function KharchuDashboard() {
                     {/* Left Side: Title & Segmented Toggle */}
                     <div className="flex items-center gap-6">
                       <h3 className="text-lg font-bold text-foreground transition-colors duration-300">Forecast Overview</h3>
-
-                      <div className="flex bg-muted rounded-xl p-1 shadow-inner border border-border transition-colors duration-300">
-                        <button
-                          onClick={() => {
-                              setGranularity('monthly');
-                              handleApplyFilters(activeFilters.includes('Global View'), 'monthly');
-                              }
-                          }
-                          className={`px-4 py-1.5 text-sm font-semibold rounded-lg transition-all duration-200 ${
-                            granularity === 'monthly'
-                              ? 'bg-card text-foreground shadow-sm'
-                              : 'text-muted-foreground hover:text-foreground'
-                          }`}
-                        >
-                          Monthly
-                        </button>
-                        <button
-                          onClick={() => {
-                              setGranularity('daily');
-                              handleApplyFilters(activeFilters.includes('Global View'), 'daily');
-                              }
-                          }
-                          className={`px-4 py-1.5 text-sm font-semibold rounded-lg transition-all duration-200 ${
-                            granularity === 'daily'
-                              ? 'bg-card text-foreground shadow-sm'
-                              : 'text-muted-foreground hover:text-foreground'
-                          }`}
-                        >
-                          Daily
-                        </button>
-                      </div>
                     </div>
 
                     {/* Right Side: Export Button (Using your Lime Green Light Accent) */}

--- a/budget_forecast_app/frontend/src/pages/KharchuDashboard/StatisticsChart.tsx
+++ b/budget_forecast_app/frontend/src/pages/KharchuDashboard/StatisticsChart.tsx
@@ -1,4 +1,4 @@
-import { BarChart2, ChevronDown } from 'lucide-react';
+import { BarChart2 } from 'lucide-react';
 import {
   ComposedChart,
   Line,
@@ -10,6 +10,7 @@ import {
   ResponsiveContainer,
   ReferenceArea,
   ReferenceLine,
+  Brush, // 1. Added Brush import
 } from 'recharts';
 
 interface ChartProps {
@@ -26,20 +27,36 @@ const formatYAxis = (value: number) => {
   return `$${value}`;
 };
 
-// 1. Tooltip Theme Fixed
-const CustomTooltip = ({ active, payload, label }: any) => {
+// Formatter function extracted to handle both XAxis and Tooltips
+const formatTimestamp = (unixTime: number | string, granularity: string) => {
+  const date = new Date(unixTime);
+  if (granularity === 'daily') {
+    return date.toLocaleDateString('en-GB', {
+        month: 'short',
+        day: '2-digit',
+        year: 'numeric'
+    }).replace(/ /g, '-');
+  }
+  return date.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
+};
+
+// 2. Updated Tooltip to handle numeric timestamp labels
+const CustomTooltip = ({ active, payload, label, granularity }: any) => {
   if (active && payload && payload.length) {
     return (
       <div className="bg-card border border-border rounded-xl p-4 shadow-xl z-50 transition-colors duration-300">
-        <p className="font-bold text-foreground mb-2 transition-colors duration-300">{label}</p>
+        <p className="font-bold text-foreground mb-2 transition-colors duration-300">
+          {formatTimestamp(label, granularity)}
+        </p>
         {payload.map((entry: any, index: number) => {
           if (entry.dataKey === 'confidenceBand') return null;
 
-          // Note: entry.color comes from the Line stroke prop, which we dynamically set below!
           return (
             <p key={index} className="text-sm flex justify-between space-x-4" style={{ color: entry.color }}>
               <span className="font-semibold">{entry.name}:</span>
-              <span className="text-foreground transition-colors duration-300">${Math.round(entry.value || 0).toLocaleString()}</span>
+              <span className="text-foreground transition-colors duration-300">
+                ${Math.round(entry.value || 0).toLocaleString()}
+              </span>
             </p>
           );
         })}
@@ -58,44 +75,33 @@ export function StatisticsChart({ forecast = [], historical = [], granularity = 
   const historicalArray = Array.isArray(safeHistorical) ? safeHistorical : [];
 
   const formattedData: any[] = [];
-  let splitDateName = "";
+  let splitTimestamp: number | null = null; // Changed to hold numeric timestamp
 
-  const formatDateKey = (ds: string) => {
-    const date = new Date(ds);
-    if (granularity === 'daily') {
-      return date.toLocaleDateString('en-GB', {
-          month: 'short',
-          day: '2-digit',
-          year: 'numeric'
-      }).replace(/ /g, '-');
-    }
-    return date.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
-  };
-
+  // 3. Map data using UNIX timestamps instead of string categories
   historicalArray.forEach((item: any) => {
     if (!item.ds) return;
-    const dateString = formatDateKey(item.ds);
+    const timestamp = new Date(item.ds).getTime();
 
     formattedData.push({
-      name: dateString,
+      timestamp,
       actual: Number(item.y) || 0,
       predicted: null,
       confidenceBand: null,
     });
-    splitDateName = dateString;
+    splitTimestamp = timestamp; // Track the last historical point
   });
 
   forecastArray.forEach((item: any) => {
     if (!item.ds || !item.yhat) return;
-    const dateString = formatDateKey(item.ds);
+    const timestamp = new Date(item.ds).getTime();
 
-    const existingPoint = formattedData.find(d => d.name === dateString);
+    const existingPoint = formattedData.find(d => d.timestamp === timestamp);
 
     if (existingPoint) {
       existingPoint.predicted = Number(item.yhat) || 0;
     } else {
       formattedData.push({
-        name: dateString,
+        timestamp,
         actual: null,
         predicted: Number(item.yhat) || 0,
         confidenceBand: item.yhat_lower ? [Number(item.yhat_lower), Number(item.yhat_upper)] : null,
@@ -103,7 +109,9 @@ export function StatisticsChart({ forecast = [], historical = [], granularity = 
     }
   });
 
-  // 2. Empty State Theme Fixed
+  // Sort data by timestamp just to be safe for continuous scaling
+  formattedData.sort((a, b) => a.timestamp - b.timestamp);
+
   if (formattedData.length === 0) {
     return (
       <div className="bg-card rounded-[24px] p-6 shadow-sm border border-border flex-1 flex items-center justify-center min-h-[400px] transition-colors duration-300">
@@ -112,11 +120,13 @@ export function StatisticsChart({ forecast = [], historical = [], granularity = 
     );
   }
 
-  // 3. Main Chart Theme Fixed
+  // 4. Calculate default zoom for Brush (e.g., zoom in on the last 60 points if daily)
+  const dataLength = formattedData.length;
+  const brushStartIndex = granularity === 'daily' ? Math.max(0, dataLength - 60) : 0;
+
   return (
     <div className="bg-card rounded-[24px] p-6 shadow-sm border border-border flex-1 flex flex-col transition-colors duration-300">
 
-      {/* Chart Header & Legend */}
       <div className="flex justify-between items-center mb-6">
         <div className="flex items-center space-x-6 w-full">
           <div className="flex items-center space-x-2">
@@ -132,7 +142,6 @@ export function StatisticsChart({ forecast = [], historical = [], granularity = 
               <span className="text-sm font-medium text-muted-foreground transition-colors duration-300">Historical</span>
             </div>
             <div className="flex items-center space-x-1.5">
-              {/* Uses your lime green accent natively */}
               <div className="w-2.5 h-2.5 rounded-full bg-light-accent transition-colors duration-300"></div>
               <span className="text-sm font-medium text-muted-foreground transition-colors duration-300">Predicted</span>
             </div>
@@ -144,10 +153,8 @@ export function StatisticsChart({ forecast = [], historical = [], granularity = 
         <ResponsiveContainer width="100%" height="100%">
           <ComposedChart data={formattedData} margin={{ top: 20, right: 30, left: 20, bottom: 20 }}>
 
-            {/* 4. Chart SVG Gradients & Definitions */}
             <defs>
               <pattern id="diagonalHatch" width="8" height="8" patternTransform="rotate(45 0 0)" patternUnits="userSpaceOnUse">
-                {/* Changed stroke to var(--muted) so the shading matches the theme */}
                 <line x1="0" y1="0" x2="0" y2="8" stroke="var(--muted)" strokeWidth="4" />
               </pattern>
               <linearGradient id="colorBand" x1="0" y1="0" x2="0" y2="1">
@@ -156,30 +163,44 @@ export function StatisticsChart({ forecast = [], historical = [], granularity = 
               </linearGradient>
             </defs>
 
-            {/* 5. Chart Grid & Axes using CSS Variables */}
             <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="var(--border)" />
 
-            <XAxis dataKey="name" minTickGap={40} axisLine={false} tickLine={false} tick={{ fill: 'var(--muted-foreground)', fontSize: 12 }} dy={10} />
+            {/* 5. Update XAxis to scale continuously over time */}
+            <XAxis
+              dataKey="timestamp"
+              type="number"
+              scale="time"
+              domain={['dataMin', 'dataMax']}
+              minTickGap={40}
+              axisLine={false}
+              tickLine={false}
+              tick={{ fill: 'var(--muted-foreground)', fontSize: 12 }}
+              dy={10}
+              tickFormatter={(unixTime) => formatTimestamp(unixTime, granularity)}
+            />
+
             <YAxis axisLine={false} tickLine={false} tick={{ fill: 'var(--muted-foreground)', fontSize: 12 }} tickFormatter={formatYAxis} dx={-10} />
 
-            <Tooltip content={<CustomTooltip />} cursor={{ stroke: 'var(--muted-foreground)', strokeWidth: 1, strokeDasharray: '5 5' }} />
+            <Tooltip
+              content={<CustomTooltip granularity={granularity} />}
+              cursor={{ stroke: 'var(--muted-foreground)', strokeWidth: 1, strokeDasharray: '5 5' }}
+            />
 
-            {splitDateName && (
+            {/* 6. Update References to use the numeric timestamp */}
+            {splitTimestamp && (
               <>
                 <ReferenceArea
-                  x1={splitDateName}
+                  x1={splitTimestamp}
                   fill="var(--muted)"
                   fillOpacity={0.10}
                   strokeOpacity={0.3}
                 />
-                <ReferenceLine x={splitDateName} stroke="var(--foreground)" strokeWidth={1} strokeDasharray="3 3" />
+                <ReferenceLine x={splitTimestamp} stroke="var(--foreground)" strokeWidth={1} strokeDasharray="3 3" />
               </>
             )}
 
             <Area type="monotone" dataKey="confidenceBand" stroke="none" fill="url(#colorBand)" />
 
-            {/* 6. The Chart Lines! */}
-            {/* Historical Line: Uses var(--foreground), with dots that match the card background to punch holes out! */}
             <Line
               type="monotone"
               dataKey="actual"
@@ -191,7 +212,6 @@ export function StatisticsChart({ forecast = [], historical = [], granularity = 
               connectNulls
             />
 
-            {/* Forecast Line: Uses var(--light-accent) */}
             <Line
               type="monotone"
               dataKey="predicted"
@@ -202,6 +222,16 @@ export function StatisticsChart({ forecast = [], historical = [], granularity = 
               activeDot={{ r: 6, fill: 'var(--light-accent)', strokeWidth: 0 }}
               name="Forecast"
               connectNulls
+            />
+
+            {/* 7. Added the Brush component for zooming/panning */}
+            <Brush
+              dataKey="timestamp"
+              height={30}
+              stroke="var(--foreground)"
+              fill="var(--card)"
+              tickFormatter={(unixTime) => formatTimestamp(unixTime, granularity)}
+              startIndex={brushStartIndex}
             />
 
           </ComposedChart>


### PR DESCRIPTION
### Overview
- Added interactive Brush component for zooming and panning across dense daily datasets.
- Fixed backend granularity fallback where 'daily' was defaulting to monthly due to case-sensitive Enum matching.
- Updated pandas resampling logic to dynamically switch between 'D' and 'MS' based on requested granularity.
- Refactored frontend chart to use numeric time scales instead of categorical strings to prevent data cramping.
- Removed the daily/monthly tab in the Dashboard at Forecast Overview to maintain URL consistency.